### PR TITLE
add stagger-launch config option; fix handling of number config values

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -100,3 +100,8 @@ options:
       default ones.
     type: string
     default:
+  stagger-launch:
+    description: |
+      Ratio, between 0 and 1, by which to stagger various tasks of Landscape.
+    type: float
+    default: 0.1

--- a/src/charm.py
+++ b/src/charm.py
@@ -146,6 +146,10 @@ class LandscapeClientCharm(CharmBase):
             if key == "ssl-public-key":
                 value = parse_ssl_arg(value)
 
+            if isinstance(value, (int, float)):
+                # `Popen` can't handle ints and floats.
+                value = str(value)
+
             configs.append("--" + key)
             configs.append(value)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -146,9 +146,8 @@ class LandscapeClientCharm(CharmBase):
             if key == "ssl-public-key":
                 value = parse_ssl_arg(value)
 
-            if isinstance(value, (int, float)):
-                # `Popen` can't handle ints and floats.
-                value = str(value)
+            # `Popen` can't handle non-string/bytes arguments.
+            value = str(value)
 
             configs.append("--" + key)
             configs.append(value)


### PR DESCRIPTION
To test:
1. pack the charm
2. deploy it with the additional `--config stagger-launch=0.99`
3. relate it to a machine charm
4. Ensure that the /etc/landscape/client.conf file contains `stagger_launch = 0.99`
5. (Optional) check that services start up staggered