### PR TITLE
Remove riscv which causes errors

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -9,10 +9,10 @@ bases:
     run-on:
     - name: "ubuntu"
       channel: "22.04"
-      architectures: [amd64, arm64, ppc64el, s390x, riscv64]
+      architectures: [amd64, arm64, ppc64el, s390x]
     - name: "ubuntu"
       channel: "23.04"
-      architectures: [amd64, arm64, ppc64el, s390x, riscv64]
+      architectures: [amd64, arm64, ppc64el, s390x]
     - name: "ubuntu"
       channel: "20.04"
-      architectures: [amd64, arm64, ppc64el, s390x, riscv64]
+      architectures: [amd64, arm64, ppc64el, s390x]


### PR DESCRIPTION
Fixes this 'architecture "riscv64" not valid' error