### PR TITLE
support config for disabling unattended-upgrades

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -105,3 +105,9 @@ options:
       Ratio, between 0 and 1, by which to stagger various tasks of Landscape.
     type: float
     default: 0.1
+  disable-unattended-upgrades:
+    description: |
+      If true, an override will be set in apt to disable unattended-upgrades
+      regardless of the setting created by the unattended-upgrades package.
+    type: boolean
+    default: false

--- a/src/charm.py
+++ b/src/charm.py
@@ -26,7 +26,10 @@ CLIENT_CONFIG_CMD = "/usr/bin/landscape-config"
 CLIENT_PACKAGE = "landscape-client"
 
 # These configs are not part of landscape client so we don't pass them to it
-CHARM_ONLY_CONFIGS = ["ppa"]
+CHARM_ONLY_CONFIGS = [
+    "ppa",
+    "disable-unattended-upgrades",
+]
 
 
 class ClientCharmError(Exception):
@@ -175,9 +178,11 @@ class LandscapeClientCharm(CharmBase):
 
     def _on_config_changed(self, _):
         if self.config.get("disable-unattended-upgrades"):
+            log_info("Disabling unattended-upgrades via APT config...")
             with open(APT_CONF_OVERRIDE, "w") as override_fp:
                 override_fp.write('APT::Periodic::Unattended-Upgrade "0";')
         elif os.path.exists(APT_CONF_OVERRIDE):
+            log_info("Enabling unattended-upgrades via APT config...")
             os.remove(APT_CONF_OVERRIDE)
 
         try:

--- a/src/charm.py
+++ b/src/charm.py
@@ -20,6 +20,7 @@ from charms.operator_libs_linux.v0 import apt
 
 logger = logging.getLogger(__name__)
 
+APT_CONF_OVERRIDE = "/etc/apt/apt.conf.d/99landscapeoverride"
 CERT_FILE = "/etc/ssl/certs/landscape_server_ca.crt"
 CLIENT_CONFIG_CMD = "/usr/bin/landscape-config"
 CLIENT_PACKAGE = "landscape-client"
@@ -173,6 +174,12 @@ class LandscapeClientCharm(CharmBase):
             self.unit.status = BlockedStatus(str(exc))
 
     def _on_config_changed(self, _):
+        if self.config.get("disable-unattended-upgrades"):
+            with open(APT_CONF_OVERRIDE, "w") as override_fp:
+                override_fp.write('APT::Periodic::Unattended-Upgrade "0";')
+        elif os.path.exists(APT_CONF_OVERRIDE):
+            os.remove(APT_CONF_OVERRIDE)
+
         try:
             apt.DebianPackage.from_installed_package(CLIENT_PACKAGE)
         except apt.PackageNotFoundError:


### PR DESCRIPTION
fixes #4 
Testing is pretty simple. Pack the charm and either deploy with `--config disable-unattended-upgrades=true` or change the config after deployment with `juju config landscape-client disable-unattended-upgrades=true`.
Verify that `/etc/apt/apt.conf.d/99landscapeoverride` exists and contains the setting `APT::Periodic::Unattended-Upgrade "0";`.

A little trickier to test that unattended-upgrades do not happen, unless you happen to have some pending.