### PR TITLE
Registration and config fixes

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -5,3 +5,7 @@ upgrade:
   description: Upgrade software on the Landscape Client unit. This will update
     APT package indices and upgrade the landscape-client package. Landscape
     client will be restarted
+
+register:
+  description: Register landscape client. Note that this will send a new
+    registration request to the server (clearing the previous one)

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -21,6 +21,6 @@ description: |
 
 subordinate: true
 requires:
-  mycontainer:
+  container:
     interface: juju-info
     scope: container


### PR DESCRIPTION
Fixing bug regarding client re-registering when juju config-changed event is happening. (This was because of in function `main()` in landscape/client/configuration.py https://github.com/canonical/landscape-client/blob/2044c7b385ab65934a97d0a91515f2a2d9a6f90f/landscape/client/configuration.py#L945 it always re-registers in --silent mode but not in wizard mode).

The fix in the charm is to use client.conf instead of landscape-config so that when the config-changed event happens, the charm will check if it's already been registered and if so only restart landscape-client instead of register again. In addition, in order to register again there is a charm action.

See bugs here:
https://bugs.launchpad.net/landscape-client-charm/+bug/2045295
https://github.com/canonical/landscape-client-charm/issues/8

In addition the computer-title has been assigned a default value of the hostname:
https://github.com/canonical/landscape-client-charm/issues/7

In addition the relation name has been changed:
https://github.com/canonical/landscape-client-charm/issues/9