### PR TITLE
fix: rename ssl-public-key parameter

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -40,12 +40,17 @@ options:
       Normally http://fqdn/ping.
     type: string
     default:
-  ssl-public-key:
+  ssl-ca:
     description: |
       The CA certificate to verify the server certificate with. This can be
       a path to a file, or a base64 encoded entry of the certificate itself,
       prefixed with "base64:". This config is only used if the message server
       URL given above starts with https.
+    type: string
+    default:
+  ssl-public-key:
+    description: |
+      DEPRECATED: Use ssl-ca instead. Will be removed in 26.04 release
     type: string
     default:
   account-name:

--- a/src/charm.py
+++ b/src/charm.py
@@ -70,19 +70,17 @@ def write_certificate(certificate, filename):
 
 def parse_ssl_arg(value):
     """
-    If ssl config starts with 'base64' or is too long to be a file, decode
-    and write it to the default cert path, return the default path. Else
-    make sure the file exists and return the original value
+    Check for file, return if exists.
+    Otherwise decode from base64 and write to_location
     """
-    b64_prefix = "base64:"
-    if value.startswith(b64_prefix) or len(value) > 4096:
-        value = re.sub("^" + b64_prefix, "", value)
+    if os.path.isfile(value):
+        return value
+    try:
         write_certificate(value, CERT_FILE)
         value = CERT_FILE
-    else:
-        if not os.path.isfile(value):
-            log_error("Cert {} does not exist!".format(value))
-            raise ClientCharmError("Certificate does not exist!")
+    except OSError:
+        log_error("Cert {} does not exist!".format(value))
+        raise ClientCharmError("Certificate does not exist!")
 
     return value
 
@@ -201,8 +199,8 @@ def create_client_config(
 
     client_config.setdefault("computer_title", default_computer_title)
 
-    if ssl_key := client_config.get("ssl_public_key"):
-        client_config["ssl_public_key"] = parse_ssl_arg(ssl_key)
+    if ssl_key := client_config.get("ssl_ca"):
+        client_config["ssl_ca"] = parse_ssl_arg(ssl_key)
 
     return client_config
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -201,7 +201,9 @@ def create_client_config(
 
     if ssl_key := client_config.get("ssl_ca"):
         client_config["ssl_ca"] = parse_ssl_arg(ssl_key)
-
+    elif ssl_key := client_config.get("ssl_public_key"):
+        client_config["ssl_public_key"] = parse_ssl_arg(ssl_key)
+        logging.warning("`ssl_public_key` is deprecated; " "use `ssl_ca` instead.")
     return client_config
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -150,12 +150,29 @@ class TestCharm(unittest.TestCase):
 
         self.open_mock().write.assert_called_once_with(data)
 
-    def test_ssl_cert_invalid_file(self):
+    @mock.patch("charm.os.path.isfile", return_value=True)
+    @mock.patch("charm.merge_client_config")
+    def test_ssl_cert_valid_path(self, merge_client_config_mock, _):
         self.harness.begin()
-        self.harness.update_config({"ssl-ca": "/path/to/nowhere"})
-        status = self.harness.charm.unit.status
-        self.assertEqual(status.message, "Certificate does not exist!")
-        self.assertIsInstance(status, BlockedStatus)
+        self.harness.update_config(
+            {"ssl-ca": "/etc/ssl/certs/landscape_server_cal.crt"}
+        )
+        self.assertEqual(
+            "/etc/ssl/certs/landscape_server_cal.crt",
+            merge_client_config_mock.call_args.args[1]["ssl_ca"],
+        )
+
+    @mock.patch("charm.os.path.isfile", return_value=False)
+    @mock.patch("charm.merge_client_config")
+    @mock.patch("charm.write_certificate", side_effect=OSError("write failed"))
+    def test_ssl_cert_oserror(
+        self, _write_certificate, merge_client_config_mock, _isfile
+    ):
+        self.harness.begin()
+        self.harness.update_config({"ssl-ca": "badcert"})
+        merge_client_config_mock.assert_not_called()
+        self.assertIsInstance(self.harness.model.unit.status, BlockedStatus)
+        self.assertIn("Certificate does not exist", str(self.harness.model.unit.status))
 
     def test_relation_broken(self):
         self.harness.begin()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -145,15 +145,14 @@ class TestCharm(unittest.TestCase):
         self.harness.begin()
 
         data = b"hello"
-
-        data_b64 = "base64:" + base64.b64encode(data).decode()
-        self.harness.update_config({"ssl-public-key": data_b64})
+        data_b64 = base64.b64encode(data).decode()  # no 'base64:' prefix
+        self.harness.update_config({"ssl-ca": data_b64})
 
         self.open_mock().write.assert_called_once_with(data)
 
     def test_ssl_cert_invalid_file(self):
         self.harness.begin()
-        self.harness.update_config({"ssl-public-key": "/path/to/nowhere"})
+        self.harness.update_config({"ssl-ca": "/path/to/nowhere"})
         status = self.harness.charm.unit.status
         self.assertEqual(status.message, "Certificate does not exist!")
         self.assertIsInstance(status, BlockedStatus)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -139,6 +139,18 @@ class TestCharm(unittest.TestCase):
         self.assertNotIn("ppa", merge_client_config_mock.call_args.args[1])
 
     @mock.patch("charm.merge_client_config")
+    def test_ssl_public_key(self, merge_client_config_mock):
+        """Test that the base64 encoded ssl cert gets written successfully"""
+
+        self.harness.begin()
+
+        data = b"hello"
+        data_b64 = base64.b64encode(data).decode()  # no 'base64:' prefix
+        self.harness.update_config({"ssl-public-key": data_b64})
+
+        self.open_mock().write.assert_called_once_with(data)
+
+    @mock.patch("charm.merge_client_config")
     def test_ssl_cert(self, merge_client_config_mock):
         """Test that the base64 encoded ssl cert gets written successfully"""
 


### PR DESCRIPTION
### Context
`ssl-public-key` is misleading. CA certificate is used to verify a Landscape server. To be consistent with other charms (e.g. OpenStack), `ssl-ca` will be used instead. `ssl-public-key` will be supported until 26.04.

### Jira
https://warthogs.atlassian.net/browse/LNDENG-2917

### Manual Testing
`tox run -e unit`
